### PR TITLE
Change shebang lines to python3

### DIFF
--- a/checkout_externals
+++ b/checkout_externals
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Main driver wrapper around the manic/checkout utility.
 

--- a/manic/checkout.py
+++ b/manic/checkout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Tool to assemble repositories represented in a model-description file.

--- a/manic/externals_description.py
+++ b/manic/externals_description.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Model description
 

--- a/manic/utils.py
+++ b/manic/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Common public utilities for manic package
 

--- a/test/test_sys_checkout.py
+++ b/test/test_sys_checkout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 

--- a/test/test_sys_repository_git.py
+++ b/test/test_sys_repository_git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Tests of some of the functionality in repository_git.py that actually
 interacts with git repositories.

--- a/test/test_unit_externals_description.py
+++ b/test/test_unit_externals_description.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 

--- a/test/test_unit_externals_status.py
+++ b/test/test_unit_externals_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for the manic external status reporting module.
 

--- a/test/test_unit_repository.py
+++ b/test/test_unit_repository.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 

--- a/test/test_unit_repository_git.py
+++ b/test/test_unit_repository_git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 

--- a/test/test_unit_repository_svn.py
+++ b/test/test_unit_repository_svn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 

--- a/test/test_unit_utils.py
+++ b/test/test_unit_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Unit test driver for checkout_externals
 


### PR DESCRIPTION
Change shebang lines to python3



User interface changes?: [No
[ If yes, describe what changed, and steps taken to ensure backward compatibilty ]

Fixes: #160 

Testing:
  test removed:
  unit tests: Ran 118 tests in 0.041s
  system tests:
  manual testing: Ran checkout_externals -o and checkout_externals -S for cesm2_3

