### PR TITLE
defer svn access to github error to actual checkout point, this will …

### DIFF
--- a/manic/repository_svn.py
+++ b/manic/repository_svn.py
@@ -42,9 +42,6 @@ class SvnRepository(Repository):
         Parse repo (a <repo> XML element).
         """
         Repository.__init__(self, component_name, repo)
-        if 'github.com' in self._url:
-            msg = "SVN access to github.com is no longer supported"
-            fatal_error(msg)
         self._ignore_ancestry = ignore_ancestry
         if self._url.endswith('/'):
             # there is already a '/' separator in the URL; no need to add another
@@ -77,6 +74,9 @@ class SvnRepository(Repository):
 
         """
         repo_dir_path = os.path.join(base_dir_path, repo_dir_name)
+        if 'github.com' in self._url:
+            msg = "SVN access to github.com is no longer supported"
+            fatal_error(msg)
         if os.path.exists(repo_dir_path):
             cwd = os.getcwd()
             os.chdir(repo_dir_path)


### PR DESCRIPTION
…allow updates from no longer supported repos

[ 50 character, one line summary ]

Defer the svn access to github error to the actual checkout point, this allows code updates from no longer supported 
repos to work correctly. 

User interface changes?:  No

Fixes: #209 

Testing:
  test removed: None
  unit tests:all pass
  system tests:all pass
  manual testing: updated as documented in #209

